### PR TITLE
Refactor health route into service layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,25 @@ A lightweight and opinionated Go microservice blueprint with structured folders,
 .
 ├── Dockerfile
 ├── Makefile
-├── api
-│   └── routes.go
 ├── cmd
 │   └── main.go
-├── config
-│   └── logger.go
+├── internal
+│   ├── api
+│   │   ├── routes.go
+│   │   └── health_routes.go
+│   ├── handlers
+│   │   └── health.go
+│   ├── services
+│   │   └── health.go
+│   ├── repositories
+│   │   └── health.go
+│   ├── config
+│   │   └── logger.go
+│   └── telemetry
+│       └── tracer.go
 ├── docker-compose.dev.yaml
 ├── go.mod
 ├── go.sum
-├── telemetry
-│   └── tracer.go
 └── tests
     └── health_test.go
 ```

--- a/internal/api/health_routes.go
+++ b/internal/api/health_routes.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"template/internal/handlers"
+	"template/internal/repositories"
+	"template/internal/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+func registerHealthRoutes(r *gin.Engine) {
+	repo := repositories.StaticHealthRepository{}
+	svc := services.NewHealthService(repo)
+	h := handlers.NewHealthHandler(svc)
+
+	r.GET("/health", h.HealthCheck)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1,17 +1,7 @@
 package api
 
-import (
-	"net/http"
-
-	"github.com/gin-gonic/gin"
-)
+import "github.com/gin-gonic/gin"
 
 func RegisterRoutes(r *gin.Engine) {
-	r.GET("/health", HealthCheckHandler)
-}
-
-func HealthCheckHandler(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"status": "healthy",
-	})
+	registerHealthRoutes(r)
 }

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"template/internal/services"
+)
+
+type HealthHandler struct {
+	svc *services.HealthService
+}
+
+func NewHealthHandler(svc *services.HealthService) *HealthHandler {
+	return &HealthHandler{svc: svc}
+}
+
+func (h *HealthHandler) HealthCheck(c *gin.Context) {
+	status := h.svc.Check()
+	c.JSON(http.StatusOK, gin.H{"status": status})
+}

--- a/internal/repositories/health.go
+++ b/internal/repositories/health.go
@@ -1,0 +1,11 @@
+package repositories
+
+type HealthRepository interface {
+	Status() string
+}
+
+type StaticHealthRepository struct{}
+
+func (StaticHealthRepository) Status() string {
+	return "healthy"
+}

--- a/internal/services/health.go
+++ b/internal/services/health.go
@@ -1,0 +1,15 @@
+package services
+
+import "template/internal/repositories"
+
+type HealthService struct {
+	repo repositories.HealthRepository
+}
+
+func NewHealthService(repo repositories.HealthRepository) *HealthService {
+	return &HealthService{repo: repo}
+}
+
+func (s *HealthService) Check() string {
+	return s.repo.Status()
+}


### PR DESCRIPTION
## Summary
- modularize health routes
- create service, repository and handler layers for health
- update README structure

## Testing
- `go test ./...` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_6860915465b88323b122f277e5acdbe0